### PR TITLE
[Patch/Breaking] readdir / readdirSync support for multiple fss

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ],
     "transformIgnorePatterns": [],
     "transform": {
-      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": ".*/__tests__/.*\\.(test|spec)\\.(jsx?|tsx?)$"
   }

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -1,7 +1,6 @@
 import {Union} from '..';
 import {Volume} from 'memfs/src/volume';
 import * as fs from 'fs';
-import { doesNotThrow } from 'assert';
 
 describe('union', () => {
     describe('Union', () => {

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -1,6 +1,7 @@
 import {Union} from '..';
 import {Volume} from 'memfs/src/volume';
 import * as fs from 'fs';
+import { doesNotThrow } from 'assert';
 
 describe('union', () => {
     describe('Union', () => {
@@ -10,6 +11,16 @@ describe('union', () => {
                 const ufs = new Union as any;
                 ufs.use(vol);
                 expect(ufs.readFileSync('/foo', 'utf8')).toBe('bar');
+            });
+
+            it('basic two filesystems', () => {
+                const vol = Volume.fromJSON({'/foo': 'bar'});
+                const vol2 = Volume.fromJSON({'/foo': 'baz'});
+                const ufs = new Union as any;
+                ufs.use(vol);
+                ufs.use(vol2);
+
+                expect(ufs.readFileSync('/foo', 'utf8')).toBe('baz');
             });
 
             it('File not found', () => {
@@ -50,6 +61,33 @@ describe('union', () => {
                     expect(ufs.existsSync("/tmp/foo.js")).toBe(true);
                 });
             });
+
+            describe("readdirSync", () => {
+                it('reads one memfs correctly', () => {
+                    const vol = Volume.fromJSON({
+                        '/foo/bar': 'bar',
+                        '/foo/baz': 'baz',
+                    });
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    expect(ufs.readdirSync("/foo")).toEqual(["bar", "baz"]);
+                });
+    
+                it('reads multiple memfs correctly', () => {
+                    const vol = Volume.fromJSON({
+                        '/foo/bar': 'bar',
+                        '/foo/baz': 'baz',
+                    });
+                    const vol2 = Volume.fromJSON({
+                        '/foo/qux': 'baz',
+                    });
+                    
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    expect(ufs.readdirSync("/foo")).toEqual(["qux", "bar", "baz"]);
+                });
+            });
         });
         describe('async methods', () => {
             it('Basic one file system', done => {
@@ -62,7 +100,16 @@ describe('union', () => {
                     done();
                 });
             });
-
+            it('basic two filesystems', () => {
+                const vol = Volume.fromJSON({'/foo': 'bar'});
+                const vol2 = Volume.fromJSON({'/foo': 'baz'});
+                const ufs = new Union as any;
+                ufs.use(vol);
+                ufs.use(vol2);
+                ufs.readFile('/foo', 'utf8', (err, content) => {
+                    expect(content).toBe('baz');
+                });
+            });
             it('File not found', done => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
                 const ufs = new Union as any;
@@ -89,6 +136,59 @@ describe('union', () => {
                 ufs.stat('/foo2', 'utf8', (err, data) => {
                     expect(err.message).toBe('No file systems attached.');
                     done();
+                });
+            });
+
+            it('callbacks are only called once', done => {
+                const vol = Volume.fromJSON({
+                    '/foo/bar': 'bar',
+                });
+                const vol2 = Volume.fromJSON({
+                    '/foo/bar': 'baz',
+                });
+                
+                const ufs = new Union() as any;
+                ufs.use(vol as any);
+                ufs.use(vol2 as any);
+
+                const mockCallback = jest.fn();
+                ufs.readFile("/foo/bar", "utf8", () => {
+                    mockCallback();
+                    expect(mockCallback).toBeCalledTimes(1);
+                    done();
+                });
+
+            });
+
+            describe("readdir", () => {
+                it('reads one memfs correctly', () => {
+                    const vol = Volume.fromJSON({
+                        '/foo/bar': 'bar',
+                        '/foo/baz': 'baz',
+                    });
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.readdir("/foo", (err, files) => {
+                        expect(files).toEqual(["bar", "baz"]);
+                    });
+                });
+    
+                it('reads multiple memfs correctly', done => {
+                    const vol = Volume.fromJSON({
+                        '/foo/bar': 'bar',
+                        '/foo/baz': 'baz',
+                    });
+                    const vol2 = Volume.fromJSON({
+                        '/foo/qux': 'baz',
+                    });
+                    
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    ufs.readdir("/foo", (err, files) => {
+                        expect(files).toEqual(["qux", "bar", "baz"]);
+                        done();
+                    });
                 });
             });
         });

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -24,7 +24,7 @@ export interface IFS {
     unlinkSync();
     rmdirSync();
     mkdirSync();
-    readdirSync();
+    readdirSync(path: string, options?: { encoding?: string | BufferEncoding | null } | BufferEncoding | string | null): string[];
     closeSync();
     openSync();
     utimesSync();
@@ -61,7 +61,8 @@ export interface IFS {
     unlink();
     rmdir();
     mkdir();
-    readdir();
+    readdir(path: string, options: { encoding?: string | BufferEncoding | null } | BufferEncoding | string | null, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    readdir(path: string, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
     close();
     open();
     utimes();

--- a/src/union.ts
+++ b/src/union.ts
@@ -206,10 +206,7 @@ export class Union {
             // Replace `callback` with our intermediate function.
             args[lastarg] = function(err) {
                 if(err) return iterate(i + 1, err);
-                if(cb) {
-                    console.log("calling %s: %s: %s", method, i, arguments);
-                    cb.apply(cb, arguments);
-                }
+                if(cb) cb.apply(cb, arguments);
             };
 
             const j = this.fss.length - i - 1;

--- a/src/union.ts
+++ b/src/union.ts
@@ -25,6 +25,10 @@ export class Union {
             return false;
         };
 
+        // Special cases for methods which need to join their results
+        this['readdir'] = (...args) => this.asyncJoinMethod("readdir", args);
+        this['readdirSync'] = (...args) => this.syncJoinMethod("readdirSync", args);
+
         // Special case `createReadStream`
         this['createReadStream'] = path => {
             let lastError = null;
@@ -85,6 +89,28 @@ export class Union {
         return this;
     }
 
+    private syncJoinMethod(method: string, args: any[]) {
+        let lastError: IUnionFsError = null;
+        let result = [];
+        for(let i = this.fss.length - 1; i >= 0; i--) {
+            const fs = this.fss[i];
+            try {
+                if(!fs[method]) throw Error(`Method not supported: "${method}" with args "${args}"`);
+                result = result.concat(fs[method].apply(fs, args));
+            } catch(err) {
+                err.prev = lastError;
+                lastError = err;
+                if(!i) { // last one
+                    throw err;
+                } else {
+                    // Ignore error...
+                    // continue;
+                }
+            }
+        }
+        return result;
+    }
+
     private syncMethod(method: string, args: any[]) {
         let lastError: IUnionFsError = null;
         for(let i = this.fss.length - 1; i >= 0; i--) {
@@ -103,6 +129,57 @@ export class Union {
                 }
             }
         }
+    }
+
+    private asyncJoinMethod(method: string, args: any[]) {
+        let lastarg = args.length - 1;
+        let cb = args[lastarg];
+        if(typeof cb !== 'function') {
+            cb = null;
+            lastarg++;
+        }
+
+        let lastError: IUnionFsError = null;
+        let result: any[] | null = null;
+        const iterate = (i = 0, error?: IUnionFsError) => {
+            if(error) {
+                error.prev = lastError;
+                lastError = error;
+            }
+
+            // Already tried all file systems, return the last error.
+            if(i >= this.fss.length) { // last one
+                if(cb) {
+                    cb(error || Error('No file systems attached.'));
+                };
+                return;
+            }
+
+            // Replace `callback` with our intermediate function.
+            args[lastarg] = (err, resArg) => {
+                if(err) {
+                    return iterate(i + 1, err);
+                }
+                if(resArg) {
+                    result = result !== null ? result : [];
+                    result.push(...resArg);
+                }
+
+                if (i === this.fss.length - 1) {
+                    return cb(null, result);
+                } else {
+                    return iterate(i + 1, error);
+                }
+            };
+
+            const j = this.fss.length - i - 1;
+            const fs = this.fss[j];
+            const func = fs[method];
+
+            if(!func) iterate(i + 1, Error('Method not supported: ' + method));
+            else func.apply(fs, args);
+        };
+        iterate();
     }
 
     private asyncMethod(method: string, args: any[]) {
@@ -129,7 +206,10 @@ export class Union {
             // Replace `callback` with our intermediate function.
             args[lastarg] = function(err) {
                 if(err) return iterate(i + 1, err);
-                if(cb) cb.apply(cb, arguments);
+                if(cb) {
+                    console.log("calling %s: %s: %s", method, i, arguments);
+                    cb.apply(cb, arguments);
+                }
             };
 
             const j = this.fss.length - i - 1;


### PR DESCRIPTION
I noticed in using `unionfs` when combining multiple filesystems that `readdir` and `readdirSync` don't behave as expected - although I'm not sure if this is by design or just an unnoticed bug. Currently the union will return the result of the `readdir` from the first filesystem which contains the directory. However if you have multiple filesystems with that directory then it will ignore the filesystems which are added afterwards. 

I've added some tests and a patch, but this obviously breaks existing behavior. Let me know your thoughts. 