### PR TITLE
Tidy up overrides and add watch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "testRegex": ".*/__tests__/.*\\.(test|spec)\\.(jsx?|tsx?)$"
+    "testMatch": [
+      "**/src/__tests__/**/*.ts?(x)"
+    ]
   }
 }

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -59,6 +59,8 @@ describe('union', () => {
 
                     // TODO: why is this twice? 
                     expect(mockCallback).toBeCalledTimes(2);
+
+                    expect(mockCallback).toBeCalledWith('change', '/tmp/foo.js');
                 })
             })
 

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -47,6 +47,21 @@ describe('union', () => {
                 }
             });
 
+            describe("watch()", () => {
+                it("should create a watcher", () => {
+                    const ufs = new Union().use(Volume.fromJSON({"foo.js": "hello test"}, "/tmp") as any) as any;
+
+                    const mockCallback = jest.fn();
+                    const writtenContent  = "hello world";
+                    ufs.watch("/tmp/foo.js", mockCallback);
+                    
+                    ufs.writeFileSync("/tmp/foo.js", writtenContent);
+
+                    // TODO: why is this twice? 
+                    expect(mockCallback).toBeCalledTimes(2);
+                })
+            })
+
             describe('existsSync()', () => {
                 it('finds file on real file system', () => {
                     const ufs = new Union;

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -57,7 +57,6 @@ describe('union', () => {
                     
                     ufs.writeFileSync("/tmp/foo.js", writtenContent);
 
-                    // TODO: why is this twice? 
                     expect(mockCallback).toBeCalledTimes(2);
 
                     expect(mockCallback).toBeCalledWith('change', '/tmp/foo.js');

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -41,7 +41,7 @@ export interface IFS {
     createWriteStream(path:string) : WritableStream;
     watchFile();
     unwatchFile();
-    watch();
+    watch(...args): any;
     rename();
     ftruncate();
     truncate();

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,5 @@ export interface IUnionFs extends IFS {
 
 export const Union = _Union as any as (new () => IUnionFs);
 
-export const ufs = (new _Union) as any as IUnion;
+export const ufs = (new _Union) as any as IUnionFs;
 export default ufs;

--- a/src/union.ts
+++ b/src/union.ts
@@ -54,12 +54,12 @@ export class Union {
 
     constructor() {
         for(let method of fsSyncMethods) {
-            if (SPECIAL_METHODS.has(method)) { // check we don't already have a property for this method
+            if (!SPECIAL_METHODS.has(method)) { // check we don't already have a property for this method
                 this[method] = (...args) =>  this.syncMethod(method, args);
             }
         }
         for(let method of fsAsyncMethods) {
-            if (SPECIAL_METHODS.has(method)) { // check we don't already have a property for this method
+            if (!SPECIAL_METHODS.has(method)) { // check we don't already have a property for this method
                 this[method] = (...args) => this.asyncMethod(method, args);
             }
         }

--- a/src/union.ts
+++ b/src/union.ts
@@ -6,160 +6,183 @@ export interface IUnionFsError extends Error {
     prev?: IUnionFsError,
 }
 
+// special case functions
+const IGNORED_METHODS = [
+    "existsSync",
+    "readdir",
+    "readdirSync",
+    "createReadStream",
+    "createWriteStream"
+]
+
+/**
+ * Union object represents a stack of filesystems
+ */
 export class Union {
 
-    fss: IFS[] = [];
+    private fss: IFS[] = [];
 
     public ReadStream = Readable;
     public WriteStream = Writable;
 
     constructor() {
-        for(let method of fsSyncMethods) this[method] = (...args) =>  this.syncMethod(method, args);
-        for(let method of fsAsyncMethods) this[method] = (...args) => this.asyncMethod(method, args);
-
-        // Special case `existsSync` - it does not throw, always succeeds.
-        this['existsSync'] = path => {
-            for (const fs of this.fss)
-                if(fs.existsSync(path))
-                    return true;
-            return false;
-        };
-
-        // special case for readdir which should union the results
-        this['readdir'] = (...args) => {
-            let lastarg = args.length - 1;
-            let cb = args[lastarg];
-            if(typeof cb !== 'function') {
-                cb = null;
-                lastarg++;
+        for(let method of fsSyncMethods) {
+            if (IGNORED_METHODS.indexOf(method) === -1) {
+                this[method] = (...args) =>  this.syncMethod(method, args);
             }
-
-            let lastError: IUnionFsError = null;
-            let result: Set<string> | null = null;
-            const iterate = (i = 0, error?: IUnionFsError) => {
-                if(error) {
-                    error.prev = lastError;
-                    lastError = error;
-                }
-
-                // Already tried all file systems, return the last error.
-                if(i >= this.fss.length) { // last one
-                    if(cb) {
-                        cb(error || Error('No file systems attached.'));
-                    };
-                    return;
-                }
-
-                // Replace `callback` with our intermediate function.
-                args[lastarg] = (err, resArg: string[] | Buffer[]) => {
-                    if(err) {
-                        return iterate(i + 1, err);
-                    }
-                    if(resArg) {
-                        result = result !== null ? result : new Set();
-                        
-                        // Convert all results to Strings to make sure that they're deduped
-                        for (const res of resArg) {
-                            result.add(String(res));
-                        }
-                    }
-
-                    if (i === this.fss.length - 1) {
-                        return cb(null, Array.from(result).sort());
-                    } else {
-                        return iterate(i + 1, error);
-                    }
-                };
-
-                const j = this.fss.length - i - 1;
-                const fs = this.fss[j];
-                const func = fs.readdir;
-
-                if(!func) iterate(i + 1, Error('Method not supported: readdir'));
-                else func.apply(fs, args);
-            };
-            iterate();
-        };
-        this['readdirSync'] = (...args) => {
-            let lastError: IUnionFsError = null;
-            let result = new Set<string>();
-            for(let i = this.fss.length - 1; i >= 0; i--) {
-                const fs = this.fss[i];
-                try {
-                    if(!fs.readdirSync) throw Error(`Method not supported: "readdirSync" with args "${args}"`);
-                    for (const res of fs.readdirSync.apply(fs, args)) {
-                        // Convert all results to Strings to make sure that they're deduped
-                        result.add(String(res));
-                    }
-                } catch(err) {
-                    err.prev = lastError;
-                    lastError = err;
-                    if(!i) { // last one
-                        throw err;
-                    } else {
-                        // Ignore error...
-                        // continue;
-                    }
-                }
-            }
-            return Array.from(result).sort();
-        };
-
-        // Special case `createReadStream`
-        this['createReadStream'] = path => {
-            let lastError = null;
-            for (const fs of this.fss) {
-                try {
-                    if(!fs.createReadStream) throw Error(`Method not supported: "createReadStream"`);
-
-                    if (fs.existsSync && !fs.existsSync(path)) {
-                        throw new Error(`file "${path}" does not exists`);
-                    }
-
-                    const stream = fs.createReadStream(path);
-                    if (!stream) {
-                        throw new Error("no valid stream")
-                    }
-                    this.ReadStream = fs.ReadStream;
-
-                    return stream;
-                }
-                catch (err) {
-                    lastError = err;
-                }
-            }
-
-            throw lastError;
         }
-
-        // Special case `createWriteStream`
-        this['createWriteStream'] = path => {
-            let lastError = null;
-            for (const fs of this.fss) {
-                try {
-                    if(!fs.createWriteStream) throw Error(`Method not supported: "createWriteStream"`);
-
-                    fs.statSync(path); //we simply stat first to exit early for mocked fs'es
-                    //TODO which filesystem to write to?
-                    const stream = fs.createWriteStream(path);
-                    if (!stream) {
-                        throw new Error("no valid stream")
-                    }
-                    this.WriteStream = fs.WriteStream;
-
-                    return stream;
-                }
-                catch (err) {
-                    lastError = err;
-                }
+        for(let method of fsAsyncMethods) {
+            if (IGNORED_METHODS.indexOf(method) === -1) {
+                this[method] = (...args) => this.asyncMethod(method, args);
             }
-
-            throw lastError;
         }
-
     }
 
-    // Add a file system to the union.
+    public existsSync(path: string) {
+        for (const fs of this.fss)
+            if(fs.existsSync(path))
+                return true;
+        return false;
+    };
+
+    public readdir(...args) {
+        let lastarg = args.length - 1;
+        let cb = args[lastarg];
+        if(typeof cb !== 'function') {
+            cb = null;
+            lastarg++;
+        }
+
+        let lastError: IUnionFsError = null;
+        let result: Set<string> | null = null;
+        const iterate = (i = 0, error?: IUnionFsError) => {
+            if(error) {
+                error.prev = lastError;
+                lastError = error;
+            }
+
+            // Already tried all file systems, return the last error.
+            if(i >= this.fss.length) { // last one
+                if(cb) {
+                    cb(error || Error('No file systems attached.'));
+                };
+                return;
+            }
+
+            // Replace `callback` with our intermediate function.
+            args[lastarg] = (err, resArg: string[] | Buffer[]) => {
+                if(err) {
+                    return iterate(i + 1, err);
+                }
+                if(resArg) {
+                    result = result !== null ? result : new Set();
+                    
+                    // Convert all results to Strings to make sure that they're deduped
+                    for (const res of resArg) {
+                        result.add(String(res));
+                    }
+                }
+
+                if (i === this.fss.length - 1) {
+                    return cb(null, Array.from(result).sort());
+                } else {
+                    return iterate(i + 1, error);
+                }
+            };
+
+            const j = this.fss.length - i - 1;
+            const fs = this.fss[j];
+            const func = fs.readdir;
+
+            if(!func) iterate(i + 1, Error('Method not supported: readdir'));
+            else func.apply(fs, args);
+        };
+        iterate();
+    };
+
+    public readdirSync(...args) {
+        let lastError: IUnionFsError = null;
+        let result = new Set<string>();
+        for(let i = this.fss.length - 1; i >= 0; i--) {
+            const fs = this.fss[i];
+            try {
+                if(!fs.readdirSync) throw Error(`Method not supported: "readdirSync" with args "${args}"`);
+                for (const res of fs.readdirSync.apply(fs, args)) {
+                    // Convert all results to Strings to make sure that they're deduped
+                    result.add(String(res));
+                }
+            } catch(err) {
+                err.prev = lastError;
+                lastError = err;
+                if(!i) { // last one
+                    throw err;
+                } else {
+                    // Ignore error...
+                    // continue;
+                }
+            }
+        }
+        return Array.from(result).sort();
+    };
+
+    public createReadStream(path: string) {
+        let lastError = null;
+        for (const fs of this.fss) {
+            try {
+                if(!fs.createReadStream) throw Error(`Method not supported: "createReadStream"`);
+
+                if (fs.existsSync && !fs.existsSync(path)) {
+                    throw new Error(`file "${path}" does not exists`);
+                }
+
+                const stream = fs.createReadStream(path);
+                if (!stream) {
+                    throw new Error("no valid stream")
+                }
+                this.ReadStream = fs.ReadStream;
+
+                return stream;
+            }
+            catch (err) {
+                lastError = err;
+            }
+        }
+
+        throw lastError;
+    }
+
+    public createWriteStream(path: string) {
+        let lastError = null;
+        for (const fs of this.fss) {
+            try {
+                if(!fs.createWriteStream) throw Error(`Method not supported: "createWriteStream"`);
+
+                fs.statSync(path); //we simply stat first to exit early for mocked fs'es
+                //TODO which filesystem to write to?
+                const stream = fs.createWriteStream(path);
+                if (!stream) {
+                    throw new Error("no valid stream")
+                }
+                this.WriteStream = fs.WriteStream;
+
+                return stream;
+            }
+            catch (err) {
+                lastError = err;
+            }
+        }
+
+        throw lastError;
+    }
+
+    /**
+     * Adds a filesystem to the list of filesystems in the union
+     * The new filesystem object is added as the last filesystem used 
+     * when searching for a file. 
+     * 
+     * @param fs the filesystem interface to be added to the queue of FS's
+     * @returns this instance of a unionFS
+     */
     use(fs: IFS): this {
         this.fss.push(fs);
         return this;

--- a/src/union.ts
+++ b/src/union.ts
@@ -6,15 +6,6 @@ export interface IUnionFsError extends Error {
     prev?: IUnionFsError,
 }
 
-// special case functions
-const IGNORED_METHODS = [
-    "existsSync",
-    "readdir",
-    "readdirSync",
-    "createReadStream",
-    "createWriteStream"
-]
-
 /**
  * Union object represents a stack of filesystems
  */
@@ -27,12 +18,12 @@ export class Union {
 
     constructor() {
         for(let method of fsSyncMethods) {
-            if (IGNORED_METHODS.indexOf(method) === -1) {
+            if (!Object.prototype.hasOwnProperty.call(this, method)) { // check we don't already have a property for this method
                 this[method] = (...args) =>  this.syncMethod(method, args);
             }
         }
         for(let method of fsAsyncMethods) {
-            if (IGNORED_METHODS.indexOf(method) === -1) {
+            if (!Object.prototype.hasOwnProperty.call(this, method)) { // check we don't already have a property for this method
                 this[method] = (...args) => this.asyncMethod(method, args);
             }
         }

--- a/src/union.ts
+++ b/src/union.ts
@@ -13,7 +13,8 @@ const SPECIAL_METHODS = new Set([
     "createReadStream",
     "createWriteStream",
     "watch",
-    "watchFile"
+    "watchFile",
+    "unwatchFile"
 ]);
 
 const createFSProxy = watchers => new Proxy({}, {
@@ -68,6 +69,10 @@ export class Union {
             // const { method } = ufs;
             this[method] = this[method].bind(this);
         }
+    }
+
+    public unwatchFile(...args) {
+        throw new Error("unwatchFile is not supported, please use watchFile");
     }
 
     public watch(...args) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "module": "commonjs",
     "removeComments": false,
     "noImplicitAny": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "downlevelIteration": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Following reading #89 I thought I'd PR two things:

1. Tidy up some of the overrides to make it neater
2. Add a watch API which watches all the filesystems. I do this by returning a proxy object around the `FS.FSWatcher` which calls all the watchers we get back from the underlying filesystems. 
