### PR TITLE
Fix Typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 coverage
 package-lock.json
 /lib/
+/demo/**/*.js
+/src/**/*.js

--- a/demo/fs-monkey.ts
+++ b/demo/fs-monkey.ts
@@ -1,13 +1,11 @@
-import {Union} from '../src/union';
-import {Volume} from '../../memfs/src/volume';
+import {Union} from '../src';
+import {Volume} from 'memfs';
 import * as fs from 'fs';
 const {patchRequire} = require('fs-monkey');
 
 
 const vol = Volume.fromJSON({[__dirname + '/fake.js']: 'console.log("owned");'});
-const ufs = new Union as any;
-
-ufs
+const ufs = new Union()
     .use(vol)
     .use(fs);
 

--- a/demo/many-fs.ts
+++ b/demo/many-fs.ts
@@ -13,7 +13,7 @@ memoryFs.writeFileSync('/memory-fs', '3');
 
 
 ufs
-    .use(fs as any)
+    .use(fs)
     .use(vol1)
     .use(vol2)
     .use(memoryFs);

--- a/demo/memfs.ts
+++ b/demo/memfs.ts
@@ -1,7 +1,6 @@
-import {Union} from '../src/union';
-import {Volume} from '../../memfs/src/volume';
+import {Union} from '../src';
+import {Volume} from 'memfs';
 import * as fs from 'fs';
-import {IFS} from "../src/fs";
 
 const vol1 = Volume.fromJSON({
     '/readme': 'hello',
@@ -11,9 +10,7 @@ const vol2 = Volume.fromJSON({
     '/dir/test/index.js': 'require("mocha")',
 });
 
-const ufs = new Union as any;
-
-ufs
+const ufs = new Union()
     .use(vol1)
     .use(vol2)
     .use(fs);

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -1,5 +1,5 @@
 import {Union} from '..';
-import {Volume} from 'memfs/src/volume';
+import {Volume} from 'memfs';
 import * as fs from 'fs';
 
 describe('union', () => {
@@ -7,7 +7,7 @@ describe('union', () => {
         describe('sync methods', () => {
             it('Basic one file system', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 expect(ufs.readFileSync('/foo', 'utf8')).toBe('bar');
             });
@@ -15,7 +15,7 @@ describe('union', () => {
             it('basic two filesystems', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
                 const vol2 = Volume.fromJSON({'/foo': 'baz'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 ufs.use(vol2);
 
@@ -24,7 +24,7 @@ describe('union', () => {
 
             it('File not found', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 try {
                     ufs.readFileSync('/not-found', 'utf8');
@@ -36,7 +36,7 @@ describe('union', () => {
 
             it('Method does not exist', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 vol.readFileSync = undefined;
                 ufs.use(vol);
                 try {
@@ -49,7 +49,7 @@ describe('union', () => {
 
             describe("watch()", () => {
                 it("should create a watcher", () => {
-                    const ufs = new Union().use(Volume.fromJSON({"foo.js": "hello test"}, "/tmp") as any) as any;
+                    const ufs = new Union().use(Volume.fromJSON({"foo.js": "hello test"}, "/tmp"));
 
                     const mockCallback = jest.fn();
                     const writtenContent  = "hello world";
@@ -68,8 +68,8 @@ describe('union', () => {
                     const ufs = new Union;
 
                     ufs
-                        .use(fs as any)
-                        .use(Volume.fromJSON({"foo.js": ""}, "/tmp") as any)
+                        .use(fs)
+                        .use(Volume.fromJSON({"foo.js": ""}, "/tmp"))
 
                     expect(ufs.existsSync(__filename)).toBe(true);
                     expect(fs.existsSync(__filename)).toBe(true);
@@ -84,7 +84,7 @@ describe('union', () => {
                         '/foo/baz': 'baz',
                     });
                     const ufs = new Union();
-                    ufs.use(vol as any);
+                    ufs.use(vol);
                     expect(ufs.readdirSync("/foo")).toEqual(["bar", "baz"]);
                 });
     
@@ -98,8 +98,8 @@ describe('union', () => {
                     });
                     
                     const ufs = new Union();
-                    ufs.use(vol as any);
-                    ufs.use(vol2 as any);
+                    ufs.use(vol);
+                    ufs.use(vol2);
                     expect(ufs.readdirSync("/foo")).toEqual(["bar", "baz", "qux"]);
                 });
 
@@ -114,8 +114,8 @@ describe('union', () => {
                     });
                     
                     const ufs = new Union();
-                    ufs.use(vol as any);
-                    ufs.use(vol2 as any);
+                    ufs.use(vol);
+                    ufs.use(vol2);
                     expect(ufs.readdirSync("/foo")).toEqual(["bar", "baz", "qux"]);
                 });
             });
@@ -123,7 +123,7 @@ describe('union', () => {
         describe('async methods', () => {
             it('Basic one file system', done => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 ufs.readFile('/foo', 'utf8', (err, data) => {
                     expect(err).toBe(null);
@@ -134,7 +134,7 @@ describe('union', () => {
             it('basic two filesystems', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
                 const vol2 = Volume.fromJSON({'/foo': 'baz'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 ufs.use(vol2);
                 ufs.readFile('/foo', 'utf8', (err, content) => {
@@ -143,7 +143,7 @@ describe('union', () => {
             });
             it('File not found', done => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 ufs.readFile('/not-found', 'utf8', (err, data) => {
                     expect(err.code).toBe('ENOENT');
@@ -153,18 +153,19 @@ describe('union', () => {
 
             it('No callback provided', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 ufs.use(vol);
                 try {
-                    ufs.stat('/foo2', 'utf8');
+                    // must be an apply so TypeScript doens't compile
+                    ufs.stat.apply(ufs, '/foo2');
                 } catch(err) {
                     expect(err).toBeInstanceOf(TypeError);
                 }
             });
 
             it('No file systems attached', done => {
-                const ufs = new Union as any;
-                ufs.stat('/foo2', 'utf8', (err, data) => {
+                const ufs = new Union();
+                ufs.stat('/foo2', (err, data) => {
                     expect(err.message).toBe('No file systems attached.');
                     done();
                 });
@@ -178,9 +179,9 @@ describe('union', () => {
                     '/foo/bar': 'baz',
                 });
                 
-                const ufs = new Union() as any;
-                ufs.use(vol as any);
-                ufs.use(vol2 as any);
+                const ufs = new Union();
+                ufs.use(vol);
+                ufs.use(vol2);
 
                 const mockCallback = jest.fn();
                 ufs.readFile("/foo/bar", "utf8", () => {
@@ -198,7 +199,7 @@ describe('union', () => {
                         '/foo/baz': 'baz',
                     });
                     const ufs = new Union();
-                    ufs.use(vol as any);
+                    ufs.use(vol);
                     ufs.readdir("/foo", (err, files) => {
                         expect(files).toEqual(["bar", "baz"]);
                     });
@@ -214,8 +215,8 @@ describe('union', () => {
                     });
                     
                     const ufs = new Union();
-                    ufs.use(vol as any);
-                    ufs.use(vol2 as any);
+                    ufs.use(vol);
+                    ufs.use(vol2);
                     ufs.readdir("/foo", (err, files) => {
                         expect(err).toBeNull();
                         expect(files).toEqual(["bar", "baz", "qux"]);
@@ -228,7 +229,7 @@ describe('union', () => {
         describe("Streams", () => {
             it("can create Readable Streams", () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
 
                 ufs.use(vol).use(fs);
 
@@ -242,7 +243,7 @@ describe('union', () => {
 
             it("can create Writable Streams", () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
-                const ufs = new Union as any;
+                const ufs = new Union();
                 const realFile = __filename+".test"
                 ufs.use(vol).use(fs);
 

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -1,78 +1,82 @@
 import { Writable, Readable } from "stream";
-import { Stats } from "fs";
+import * as fs from "fs";
 
-export interface IFS {
+type FSMethods =
+    | "readFileSync"
+    | "renameSync"
+    | "ftruncateSync"
+    | "truncateSync"
+    | "chownSync"
+    | "fchownSync"
+    | "lchownSync"
+    | "chmodSync"
+    | "fchmodSync"
+    | "lchmodSync"
+    | "statSync"
+    | "lstatSync"
+    | "fstatSync"
+    | "linkSync"
+    | "symlinkSync"
+    | "readlinkSync"
+    | "realpathSync"
+    | "unlinkSync"
+    | "rmdirSync"
+    | "mkdirSync"
+    | "readdirSync"
+    | "closeSync"
+    | "openSync"
+    | "utimesSync"
+    | "futimesSync"
+    | "fsyncSync"
+    | "writeSync"
+    | "readSync"
+    | "readFileSync"
+    | "writeFileSync"
+    | "appendFileSync"
+    | "existsSync"
+    | "accessSync"
+    | "createReadStream"
+    | "createWriteStream"
+    | "watchFile"
+    | "unwatchFile"
+    | "watch"
+    | "rename"
+    | "ftruncate"
+    | "truncate"
+    | "chown"
+    | "fchown"
+    | "lchown"
+    | "chmod"
+    | "fchmod"
+    | "lchmod"
+    | "stat"
+    | "lstat"
+    | "fstat"
+    | "link"
+    | "symlink"
+    | "readlink"
+    | "realpath"
+    | "unlink"
+    | "rmdir"
+    | "mkdir"
+    | "readdir"
+    | "readdir"
+    | "close"
+    | "open"
+    | "utimes"
+    | "futimes"
+    | "fsync"
+    | "write"
+    | "read"
+    | "readFile"
+    | "writeFile"
+    | "appendFile"
+    | "exists"
+    | "access";
+
+type FS = Pick<typeof fs, FSMethods>
+
+export interface IFS extends FS {
     WriteStream: typeof Writable;
     ReadStream: typeof Readable;
-    readFileSync();
-    renameSync();
-    ftruncateSync();
-    truncateSync();
-    chownSync();
-    fchownSync();
-    lchownSync();
-    chmodSync();
-    fchmodSync();
-    lchmodSync();
-    statSync(path:string): Stats;
-    lstatSync();
-    fstatSync();
-    linkSync();
-    symlinkSync();
-    readlinkSync();
-    realpathSync();
-    unlinkSync();
-    rmdirSync();
-    mkdirSync();
-    readdirSync(path: string, options?: { encoding?: string | BufferEncoding | null } | BufferEncoding | string | null): string[];
-    closeSync();
-    openSync();
-    utimesSync();
-    futimesSync();
-    fsyncSync();
-    writeSync();
-    readSync();
-    readFileSync();
-    writeFileSync();
-    appendFileSync();
-    existsSync(path): boolean;
-    accessSync();
-    createReadStream(path:string) : ReadableStream;
-    createWriteStream(path:string) : WritableStream;
-    watchFile();
-    unwatchFile();
-    watch(...args): any;
-    rename();
-    ftruncate();
-    truncate();
-    chown();
-    fchown();
-    lchown();
-    chmod();
-    fchmod();
-    lchmod();
-    stat();
-    lstat();
-    fstat();
-    link();
-    symlink();
-    readlink();
-    realpath();
-    unlink();
-    rmdir();
-    mkdir();
-    readdir(path: string, options: { encoding?: string | BufferEncoding | null } | BufferEncoding | string | null, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    readdir(path: string, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    close();
-    open();
-    utimes();
-    futimes();
-    fsync();
-    write();
-    read();
-    readFile();
-    writeFile();
-    appendFile();
-    exists();
-    access();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,6 @@ export type TEncoding = 'ascii' | 'utf8' | 'utf16le' | 'ucs2' | 'base64' | 'lati
 export type TEncodingExtended = TEncoding | 'buffer';
 export type TTime = number | string | Date;
 
-
-export interface IUnion {
-    use(fs: IFS): this;
-
-    readFileSync(path: TFilePath, options?: object | TEncoding);
-}
-
 export interface IUnionFs extends IFS {
     use(fs: IFS): this;
 }


### PR DESCRIPTION
I went through and fixed up the issues with typings within the public api for the library so that it’s possible to call `use` without casting anything to an `any`. Although it does feel like these typings should be in a shared place. 

Maybe it’s an idea to combine `memfs` and `fs-monkey` with this in a monorepo since they’re fairly tightly coupled. 