### PR TITLE
fix(readdirSync): 🐛  Error no such file or directory

### DIFF
--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -118,6 +118,32 @@ describe('union', () => {
                     ufs.use(vol2 as any);
                     expect(ufs.readdirSync("/foo")).toEqual(["bar", "baz", "qux"]);
                 });
+
+                it("reads other fss when one fails", () => {
+                    const vol = Volume.fromJSON({
+                      "/foo/bar": "bar",
+                      "/foo/baz": "baz"
+                    });
+                    const vol2 = Volume.fromJSON({
+                      "/bar/baz": "not baz",
+                      "/bar/qux": "baz"
+                    });
+          
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    expect(ufs.readdirSync("/bar")).toEqual(["baz", "qux"]);
+                });
+        
+                it("throws error when all fss fail", () => {
+                    const vol = Volume.fromJSON({});
+                    const vol2 = Volume.fromJSON({});
+            
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    expect(() => ufs.readdirSync("/bar")).toThrow();
+                });
             });
         });
         describe('async methods', () => {

--- a/src/union.ts
+++ b/src/union.ts
@@ -188,7 +188,7 @@ export class Union {
             } catch(err) {
                 err.prev = lastError;
                 lastError = err;
-                if(!i) { // last one
+                if(result.size === 0 && !i) { // last one
                     throw err;
                 } else {
                     // Ignore error...


### PR DESCRIPTION
* `readdirSync` throws `ENOENT: no such file or directory, scandir` when
   the directory does not exists one of the file systems.
* Problem solved checking also if there are some results before throw.

Fixes #240