### PR TITLE
fix(readdir): 🐛  Error no such file or directory

### DIFF
--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -223,6 +223,39 @@ describe('union', () => {
                         done();
                     });
                 });
+
+                it("reads other fss when one fails", done => {
+                    const vol = Volume.fromJSON({
+                        "/foo/bar": "bar",
+                        "/foo/baz": "baz"
+                    });
+                    const vol2 = Volume.fromJSON({
+                        "/bar/baz": "not baz",
+                        "/bar/qux": "baz"
+                    });
+          
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    ufs.readdir("/bar", (err, files) => {
+                        expect(err).toBeNull();
+                        expect(files).toEqual(["baz", "qux"]);
+                        done();
+                    });
+                });
+          
+                it("throws error when all fss fail", done => {
+                    const vol = Volume.fromJSON({});
+                    const vol2 = Volume.fromJSON({});
+          
+                    const ufs = new Union();
+                    ufs.use(vol as any);
+                    ufs.use(vol2 as any);
+                    ufs.readdir("/bar", (err, files) => {
+                        expect(err).not.toBeNull();
+                        done();
+                    });
+                });
             });
         });
 

--- a/src/union.ts
+++ b/src/union.ts
@@ -128,7 +128,7 @@ export class Union {
         }
 
         let lastError: IUnionFsError = null;
-        let result: Set<string> | null = null;
+        let result: Set<string> = new Set();
         const iterate = (i = 0, error?: IUnionFsError) => {
             if(error) {
                 error.prev = lastError;
@@ -145,12 +145,10 @@ export class Union {
 
             // Replace `callback` with our intermediate function.
             args[lastarg] = (err, resArg: string[] | Buffer[]) => {
-                if(err) {
+                if(result.size === 0 && err) {
                     return iterate(i + 1, err);
                 }
                 if(resArg) {
-                    result = result !== null ? result : new Set();
-
                     // Convert all results to Strings to make sure that they're deduped
                     for (const res of resArg) {
                         result.add(String(res));


### PR DESCRIPTION
- `readdir` throws ENOENT: no such file or directory, when
the directory does not exists one of the file systems.
- Problem solved checking also if there are some results before a throw.

Fixes #351 