### PR TITLE
Improve types

### DIFF
--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -37,7 +37,7 @@ describe('union', () => {
             it('Method does not exist', () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
                 const ufs = new Union();
-                vol.readFileSync = undefined;
+                vol.readFileSync = undefined as any;
                 ufs.use(vol as any);
                 try {
                     ufs.readFileSync('/foo', 'utf8');
@@ -172,7 +172,7 @@ describe('union', () => {
                 const ufs = new Union();
                 ufs.use(vol as any);
                 ufs.readFile('/not-found', 'utf8', (err, data) => {
-                    expect(err.code).toBe('ENOENT');
+                    expect(err?.code).toBe('ENOENT');
                     done();
                 });
             });
@@ -192,7 +192,7 @@ describe('union', () => {
             it('No file systems attached', done => {
                 const ufs = new Union();
                 ufs.stat('/foo2', (err, data) => {
-                    expect(err.message).toBe('No file systems attached.');
+                    expect(err?.message).toBe('No file systems attached.');
                     done();
                 });
             });
@@ -312,7 +312,7 @@ describe('union', () => {
             it('Method does not exist', async () => {
                 const vol = Volume.fromJSON({'/foo': 'bar'});
                 const ufs = new Union();
-                vol.promises.readFile = undefined;
+                vol.promises.readFile = undefined as any;
                 ufs.use(vol as any);
                 await expect(ufs.promises.readFile('/foo', 'utf8')).rejects.toThrowError();
             });

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -182,8 +182,7 @@ describe('union', () => {
                 const ufs = new Union();
                 ufs.use(vol as any);
                 try {
-                    // must be an apply so TypeScript doens't compile
-                    ufs.stat.apply(ufs, '/foo2');
+                    ufs.stat('/foo2', undefined as any);
                 } catch(err) {
                     expect(err).toBeInstanceOf(TypeError);
                 }

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -74,7 +74,7 @@ type FSMethods =
     | "exists"
     | "access";
 
-type FS = Pick<typeof fs, FSMethods>
+type FS = Pick<typeof fs, FSMethods | 'promises'>;
 
 export interface IFS extends FS {
     WriteStream: typeof Writable;

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -77,6 +77,6 @@ type FSMethods =
 type FS = Pick<typeof fs, FSMethods | 'promises'>;
 
 export interface IFS extends FS {
-    WriteStream: typeof Writable;
-    ReadStream: typeof Readable;
+    WriteStream: (typeof Writable) | (new (...args: any[]) => Writable);
+    ReadStream: (typeof Readable) | (new (...args: any[]) => Readable);
 }

--- a/src/fs.d.ts
+++ b/src/fs.d.ts
@@ -2,7 +2,6 @@ import { Writable, Readable } from "stream";
 import * as fs from "fs";
 
 type FSMethods =
-    | "readFileSync"
     | "renameSync"
     | "ftruncateSync"
     | "truncateSync"
@@ -59,7 +58,6 @@ type FSMethods =
     | "unlink"
     | "rmdir"
     | "mkdir"
-    | "readdir"
     | "readdir"
     | "close"
     | "open"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,5 @@
-import { PathLike } from 'fs';
 import {Union as _Union} from "./union";
 import {IFS} from "./fs";
-
-
-export type TFilePath = PathLike;
-export type TFileId = TFilePath | number;           // Number is used as a file descriptor.
-export type TDataOut = string | Buffer;             // Data formats we give back to users.
-export type TData = TDataOut | Uint8Array;          // Data formats users can give us.
-export type TFlags = string | number;
-export type TMode = string | number;                // Mode can be a String, although docs say it should be a Number.
-export type TEncoding = 'ascii' | 'utf8' | 'utf16le' | 'ucs2' | 'base64' | 'latin1' | 'binary' | 'hex';
-export type TEncodingExtended = TEncoding | 'buffer';
-export type TTime = number | string | Date;
 
 export interface IUnionFs extends IFS {
     use(fs: IFS): this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
+import { PathLike } from 'fs';
 import {Union as _Union} from "./union";
 import {IFS} from "./fs";
 
 
-export type TFilePath = string | Buffer | URL;
+export type TFilePath = PathLike;
 export type TFileId = TFilePath | number;           // Number is used as a file descriptor.
 export type TDataOut = string | Buffer;             // Data formats we give back to users.
 export type TData = TDataOut | Uint8Array;          // Data formats users can give us.

--- a/src/union.ts
+++ b/src/union.ts
@@ -77,8 +77,8 @@ export class Union {
 
     private fss: IFS[] = [];
 
-    public ReadStream = Readable;
-    public WriteStream = Writable;
+    public ReadStream: (typeof Readable) | (new (...args: any[]) => Readable) = Readable;
+    public WriteStream: (typeof Writable) | (new (...args: any[]) => Writable) = Writable;
 
     private promises: {} = {};
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitAny": false,
     "sourceMap": false,
     "strictNullChecks": true,
+    "strictBindCallApply": true,
     "downlevelIteration": true
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "removeComments": false,
     "noImplicitAny": false,
     "sourceMap": false,
+    "strictNullChecks": true,
     "downlevelIteration": true
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "dom",
       "es5",
       "es2015"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "sourceMap": false,
     "strictNullChecks": true,
     "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
     "downlevelIteration": true
   },
   "exclude": [


### PR DESCRIPTION
This removes the use of `URL`, meaning the `dom` lib isn't needed by downstream libraries.

(This is branched off #406)