### PR TITLE
chore: add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "unionfs",
   "version": "4.5.1",
   "description": "Use multiple `fs` modules in a union.",
+  "license": "Unlicense",
   "keywords": [
     "fs",
     "file",


### PR DESCRIPTION
Closes #461 

This PR adds the `license` key to the package.json
https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license

The "Unlicense" value is from the SPDX license list:
https://spdx.org/licenses/

Adding the license to the package.json improves support for automated license checkers that only have access to the package.json.