### PR TITLE
ci: don't test against Node v17

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
It's not an LTS version and is blocking #743 as Jest doesn't explicitly support it