### PR TITLE
fix: `createWriteStream` failing to create new files in directories

### DIFF
--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -489,6 +489,34 @@ describe('union', () => {
 
         ufs.unlinkSync(realFile);
       });
+
+      describe('createWriteStream', () => {
+        it('creates a new file when only parent directory exists', async () => {
+          const vol = Volume.fromJSON({ '/foo': null });
+          const vol2 = Volume.fromJSON({ '/bar': null });
+          const ufs = new Union();
+          ufs.use(vol as any).use(vol2 as any);
+
+          const stream = ufs.createWriteStream('/bar/file');
+          stream.end('content');
+          await new Promise(resolve => stream.once('close', resolve));
+
+          expect(vol2.readFileSync('/bar/file', 'utf8')).toBe('content');
+        });
+
+        it('writes to an existing file even if parent dir exists on an earlier fss', async () => {
+          const vol = Volume.fromJSON({ '/bar': null });
+          const vol2 = Volume.fromJSON({ '/bar/file': '' });
+          const ufs = new Union();
+          ufs.use(vol as any).use(vol2 as any);
+
+          const stream = ufs.createWriteStream('/bar/file');
+          stream.end('content');
+          await new Promise(resolve => stream.once('close', resolve));
+
+          expect(vol2.readFileSync('/bar/file', 'utf8')).toBe('content');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This issue provides most of the context: https://github.com/streamich/unionfs/issues/428

#428 suggests just to replace `fs.statSync(path)` with `fs.statSync(dirname(path))`, but that could cause surprising behavior in the case where multiple filesystems include the parent directory.

I've added a regression test for this case:  `"createWriteStream writes to an existing file even if parent dir exists on an earlier fss"`

Fixes #428
